### PR TITLE
concat the format to the temp filename

### DIFF
--- a/src/TextImage/Rendering/TextImageRenderer.php
+++ b/src/TextImage/Rendering/TextImageRenderer.php
@@ -130,7 +130,7 @@ class TextImageRenderer
                 break;
         }
 
-        $formatedFilename.=".".$format;
+        $formatedFilename = $tmpFilename.".".$format;
         @\rename($tmpFilename, $formatedFilename);
         \imagedestroy($image);
         return new Utils\Image($formatedFilename, $format);

--- a/src/TextImage/Rendering/TextImageRenderer.php
+++ b/src/TextImage/Rendering/TextImageRenderer.php
@@ -130,7 +130,7 @@ class TextImageRenderer
                 break;
         }
 
-        $formatedFilename = \str_replace('.tmp', '.' . $format, $tmpFilename);
+        $formatedFilename.=".".$format;
         @\rename($tmpFilename, $formatedFilename);
         \imagedestroy($image);
         return new Utils\Image($formatedFilename, $format);


### PR DESCRIPTION
An exception was thrown when I tried to use the code, so it turned out that the tmp file isn't adding ".tmp" at the end of the file which made this code useless:

`$formatedFilename = \str_replace('.tmp', '.' . $format, $tmpFilename);`

so I replaced it with:

`$formatedFilename=".".$format;`

I am not sure if this a php version/OS issue though!

I am using: MacOS X El Capitan - PHP 5.6.10
